### PR TITLE
Removing header from invitation page, fixing 404 page styles

### DIFF
--- a/src/components/Intro/intro.scss
+++ b/src/components/Intro/intro.scss
@@ -9,7 +9,7 @@
 
 .intro {
   width: 100%;
-  height: 616px;
+  height: 630px;
   position: relative;
   overflow: hidden;
   &-img {

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -46,7 +46,6 @@ export default class MainLayout extends React.Component {
         </Helmet>
         {/*<HeaderMenu />*/}
         <Header />
-        <Intro/>
         <div className="body">
           {children()}
         </div>

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -7,7 +7,6 @@ import './fontello.css';
 import Header from '../components/Header/Header';
 import HeaderMenu from '../components/HeaderMenu/HeaderMenu';
 import Footer from '../components/Footer/Footer';
-import Intro from '../components/Intro/Intro';
 
 export default class MainLayout extends React.Component {
   render() {

--- a/src/layouts/index.scss
+++ b/src/layouts/index.scss
@@ -50,6 +50,10 @@ body {
   font-size: 17px;
 }
 
+h1, h2, h3, h4, h5, h6, p {
+  color: $white;
+}
+
 @media (max-width: 480px) {
   body {
     .app {

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const NotFoundPage = () => (
-  <div>
+  <div className="container-fluid">
     <h1>NOT FOUND</h1>
     <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
   </div>

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,9 +1,13 @@
 import React from 'react'
+import Intro from '../components/Intro/Intro';
 
 const NotFoundPage = () => (
-  <div className="container-fluid">
-    <h1>NOT FOUND</h1>
-    <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+  <div className="not-found">
+    <Intro />
+    <div className="container-fluid">
+      <h1>NOT FOUND</h1>
+      <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+    </div>
   </div>
 )
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import "./index.scss";
 import InfoBlock from '../components/InfoBlock/InfoBlock';
-import Intro from '../components/Intro/Intro';
 import VenueBlock from '../components/VenueBlock/VenueBlock';
 import SpeakersBlock from '../components/SpeakersBlock/SpeakersBlock';
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import "./index.scss";
 import InfoBlock from '../components/InfoBlock/InfoBlock';
+import Intro from '../components/Intro/Intro';
 import VenueBlock from '../components/VenueBlock/VenueBlock';
 import SpeakersBlock from '../components/SpeakersBlock/SpeakersBlock';
 
@@ -8,6 +9,7 @@ export default class Header extends React.Component {
   render() {
     return (
       <div className="page-index lines-bg">
+        <Intro/>
         <InfoBlock />
         <SpeakersBlock />
         <VenueBlock />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import "./index.scss";
+import Intro from '../components/Intro/Intro';
 import InfoBlock from '../components/InfoBlock/InfoBlock';
 import VenueBlock from '../components/VenueBlock/VenueBlock';
 import SpeakersBlock from '../components/SpeakersBlock/SpeakersBlock';


### PR DESCRIPTION
404 page looked like this:
![image](https://user-images.githubusercontent.com/2051028/32243077-1df2ef44-be7d-11e7-8a13-9739514753bf.png)


Now it looks like this:
![image](https://user-images.githubusercontent.com/2051028/32243336-a4544d76-be7d-11e7-8bec-e69b1f33d9e9.png)


Removed header from invitation page, now it looks like this:
![image](https://user-images.githubusercontent.com/2051028/32243138-3cc3e20c-be7d-11e7-9067-a7802e887966.png)


