### PR TITLE
Remove "L sep" symbol from footer

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -23,7 +23,7 @@ export default class Footer extends React.Component {
             <div className="col-sm-6 col-xs-12">
             <strong>Subscribe</strong>
             <p>
-            Exciting things ahead,<br />  stay tuned for more information.
+            Exciting things ahead,<br />stay tuned for more information.
             </p>
             <Subscribe />
             </div>


### PR DESCRIPTION
Hi!

On windows subscribe's description in footer contains "L sep" symbol

![image](https://user-images.githubusercontent.com/948688/34103406-a4ecb7dc-e3fd-11e7-8141-876d98036a0e.png)

Looks odd =))